### PR TITLE
Update mid-vespers.tex

### DIFF
--- a/mid-vespers.tex
+++ b/mid-vespers.tex
@@ -178,11 +178,11 @@ And looketh down on the low things in heaven and in earth?
 
 \bigskip
 
-Vespers continues on page \pageref{little-chapter} with the Little Chapter.
+Las Vísperas continúan en la página \pageref{little-chapter} con el Pequeño Capítulo.
 
-\section{Advent Psalmody}
+\section{Salmodia para el Tiempo de Adviento}
 
-\subsection{First Psalm - Psalm 109}
+\subsection{Primer Salmo - Salmo 109}
 
 \gresetinitiallines1
 
@@ -195,7 +195,7 @@ Vespers continues on page \pageref{little-chapter} with the Little Chapter.
 
 \gregorioscore{gabc/an--missus_est}
 
-\subsection{Second Psalm - Psalm 112}
+\subsection{Segundo Salmo - Salmo 112}
 
 \gresetinitiallines1
 \gregorioscore{gabc/an--ave_maria..._alleluia--solesmes_1961}
@@ -207,7 +207,7 @@ Vespers continues on page \pageref{little-chapter} with the Little Chapter.
 
 \gregorioscore{gabc/an--ave_maria..._alleluia--solesmes_1961}
 
-\subsection{Third Psalm - Psalm 121}
+\subsection{Tercer Salmo - Salmo 121}
 
 \gresetinitiallines1
 \gregorioscore{gabc/an--ne_timeas--init}
@@ -219,7 +219,7 @@ Vespers continues on page \pageref{little-chapter} with the Little Chapter.
 
 \gregorioscore{gabc/an--ne_timeas--solesmes}
 
-\subsection{Fourth Psalm - Psalm 126}
+\subsection{Cuarto Salmo - Salmo 126}
 
 \gresetinitiallines1
 \gregorioscore{gabc/an--dabit_ei_dominus--init}
@@ -231,7 +231,7 @@ Vespers continues on page \pageref{little-chapter} with the Little Chapter.
 
 \gregorioscore{gabc/an--dabit_ei_dominus--solesmes_1961}
 
-\subsection{Fifth Psalm - Psalm 147}
+\subsection{Quinto Salmo - Salmo 147}
 
 \gresetinitiallines1
 \gregorioscore{gabc/an--ecce_ancilla_domini--init}
@@ -245,7 +245,7 @@ Vespers continues on page \pageref{little-chapter} with the Little Chapter.
 
 \bigskip
 
-Vespers continues on page \pageref{little-chapter} with the Little Chapter.
+Las Vísperas continúan en la página \pageref{little-chapter} con el Pequeño Capítulo.
 
 
 


### PR DESCRIPTION
Acá cambié los títulos de los Salmos de Adviento. 

Te cuento que los Salmos de Adviento son los mismos que los del resto del año, sólo cambian las antífonas y la melodía de las estrofas. 

Acá me dio susto porque se nota que el texto lo va a ir a buscar más arriba. Y no sé si al haber cambiado ciertas cosas los comandos no lo encuentren. 

Este cambio es bien importante. Y si no resulta, indagar por qué.