### PR TITLE
Traducción del cuerpo del Salmo 8. Update 8-4A.tex

### DIFF
--- a/oficio-parvo.tex
+++ b/oficio-parvo.tex
@@ -60,7 +60,7 @@ Dómine, in unióne illíus divínæ intentiónis, qua ipse in terris laudes Deo
 	Oh Señor, en unión con aquella divina intención, con la que tu mismo hiciste alabanza a Dios en la tierra, te ofrezco a ti estas horas (o esta hora).}
 \stopParallel
 
-\part{Maitines}
+\part{Maitines (Matutinum)}
 
 
 \input mid-matins

--- a/oficio-parvo.tex
+++ b/oficio-parvo.tex
@@ -133,7 +133,7 @@ Dómine, in unióne illíus divínæ intentiónis, qua ipse in terris laudes Deo
 
 \rubrics{La Hora de las Completas siempre concluye con la Antífona Mariana correspondiente, página \pageref{marian-ants}.}
 
-\chapter{Antífona Mariana }
+\chapter{Antífonas Marianas}
 
 \label{marian-ants}
 \input marianantiphon

--- a/oficio-parvo.tex
+++ b/oficio-parvo.tex
@@ -31,7 +31,7 @@
 
 \begin{document}
 
-\mytitle{Pequeño Oficio de la Bienaventurada Vírgen María}{Maitines, Vísperas y Completas}
+\mytitle{Pequeño Oficio de la Bienaventurada Virgen María}{Maitines, Vísperas y Completas}
 
 \tableofcontents*
 
@@ -106,9 +106,7 @@ Dómine, in unióne illíus divínæ intentiónis, qua ipse in terris laudes Deo
 
 % \rubrics{Es recomendable finalizar la recitación pública del Pequeño Oficio con la correspondiente Antífona Mariana, página \pageref{marian-ants}.}
 
-\part{Vesperae}
-
-Deus in adjutorium as at the beginning of Lauds(OJO, NO PUEDE HABER REFERENCIA A LAUDES PORQUE NO HABRÁ LAUDES EN NUESTRO LIBRO), page \pageref{deus-memento}
+\part{Vísperas (Vesperae)}
 
 \startParallel
 \latin{Deus in adjutórium meum intende.}
@@ -125,7 +123,7 @@ Deus in adjutorium as at the beginning of Lauds(OJO, NO PUEDE HABER REFERENCIA A
 
 \rubrics{Es recomendable finalizar la recitación pública del Pequeño Oficio con la correspondiente Antífona Mariana, página \pageref{marian-ants}.}
 
-\part{Completorium}
+\part{Completas (Completorium)}
 
 %\renewcommand{\latin}[1]{\selectlanguage{latin}\ifnum \value{versecount}>0 \stepcounter{versecount} \theversecount .~\fi#1\switchcolumn\selectlanguage{spanish}}
 %\renewcommand{\vern}[1]{\tr{#1}\switchcolumn}

--- a/psalms/8-4A.tex
+++ b/psalms/8-4A.tex
@@ -1,20 +1,20 @@
 ﻿\latin{Quóniam eleváta est magnificén\textit{ti}\textit{a} \textbf{tu}a,~* \textit{su}\textit{per} \textbf{cæ}los.}
-\vern{For thy magnificence is elevated above the heavens.}
+\vern{Porque tu majestad se ve ensalzada sobre los cielos.}
 \latin{Ex ore infántium et lacténtium perfecísti laudem propter ini\textit{mí}\textit{cos} \textbf{tu}os,~* ut déstruas inimí\textit{cum} \textit{et} \textit{ul}\textbf{tó}rem.}
-\vern{Out of the mouth of infants and of sucklings thou hast perfected praise, because of thy enemies, that thou mayst destroy the enemy and the avenger.}
+\vern{De la boca de los niños y de los que están aún pendientes del pecho de sus madres, hiciste Tú salir perfecta alabanza, por razón de tus enemigos, para destruir al enemigo y al vengativo.}
 \latin{Quóniam vidébo cælos tuos, ópera digitó\textit{rum} \textit{tu}\textbf{ó}rum:~* lunam et stellas, \textit{quæ} \textit{tu} \textit{fun}\textbf{dás}ti.}
-\vern{For I will behold thy heavens, the works of thy fingers: the moon and the stars which thou hast founded.}
+\vernYo contemplo tus cielos, obra de tus dedos, * la luna y las estrellas que Tú creaste,}
 \latin{Quid est homo quod me\textit{mor} \textit{es} \textbf{e}jus?~* aut fílius hóminis, quóniam \textit{ví}\textit{si}\textit{tas} \textbf{e}um?}
-\vern{What is man that thou art mindful of him? or the son of man that thou visitest him?}
+\vern{Y exclamo: ¿Qué es el hombre, para que Tú te acuerdes de él? * ¿O qué es el hijo del hombre, para que vengas a visitarlo?}
 \latin{Minuísti eum paulo minus ab Angelis,~† glória et honóre coro\textit{nás}\textit{ti} \textbf{e}um:~* et constituísti eum super ópera má\textit{nu}\textit{um} \textit{tu}\textbf{á}rum.}
-\vern{Thou hast made him a little less than the angels, thou hast crowned him with glory and honour: And hast set him over the works of thy hands.}
+\vern{Lo hiciste un poco inferior a los ángeles, lo coronaste de gloria y de honor, * y le has dado el mando sobre las obras de tus manos.}
 \latin{Omnia subjecísti sub pé\textit{di}\textit{bus} \textbf{e}jus,~* oves et boves univérsas: ínsuper et \textit{pé}\textit{co}\textit{ra} \textbf{cam}pi.}
-\vern{Thou hast subjected all things under his feet, all sheep and oxen: moreover the beasts also of the fields.}
+\vern{Todas ellas las pusiste a sus pies; * todas las ovejas y bueyes, y aun las bestias del campo;}
 \latin{Vólucres cæli, et \textit{pi}\textit{sces} \textbf{ma}ris,~* qui perámbulant \textit{sé}\textit{mi}\textit{tas} \textbf{ma}ris.}
-\vern{The birds of the air, and the fishes of the sea, that pass through the paths of the sea.}
+\vern{Las aves del cielo, y los peces del mar * que hienden sus olas.}
 \latin{Dómine, Dó\textit{mi}\textit{nus} \textbf{nos}ter,~* quam admirábile est nomen tuum in u\textit{ni}\textit{vér}\textit{sa} \textbf{ter}ra}
-\vern{O Lord our Lord, how admirable is thy name in all the earth!}
+\vern{¡Oh Señor, soberano dueño nuestro, * cuán admirable es tu Nombre en toda la redondez de la tierra!}
 \latin{Glória Pa\textit{tri}, \textit{et} \textbf{Fí}lio,~* et Spi\textit{rí}\textit{tu}\textit{i} \textbf{Sanc}to.}
-\vern{Glory be to the Father \ldots }
+\vern{Gloria al Padre\ldots }
 \latin{Sicut erat in princípio, et \textit{nunc}, \textit{et} \textbf{sem}per,~* et in sǽcula sæ\textit{cu}\textit{ló}\textit{rum}. \textbf{A}men.}
 


### PR DESCRIPTION
En este archivo no está la primera estrofa (entiendo por qué). Porque la primera estrofa va en el tetragrama. Además, en la versión de VB, no lleva traducción al inglés esa primera estrofa.